### PR TITLE
feat: 사용자 인증 관련 MockAPI 구현 및 테스트 추가

### DIFF
--- a/http/auth/AuthTest.http
+++ b/http/auth/AuthTest.http
@@ -33,4 +33,51 @@ Content-Type: application/json
   "name": "박지민"
 }
 
+### 사용자 로그인 성공 테스트
+# 유효한 이메일과 비밀번호로 로그인
+POST http://localhost:8080/v1/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "securePassword123"
+}
+
+### 로그인 실패 테스트 - 잘못된 이메일
+# 등록되지 않은 이메일로 로그인 시도
+POST http://localhost:8080/v1/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "invalid@example.com",
+  "password": "securePassword123"
+}
+
+### 로그인 실패 테스트 - 잘못된 비밀번호
+# 잘못된 비밀번호로 로그인 시도
+POST http://localhost:8080/v1/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "wrongpassword"
+}
+
+### 토큰 갱신 성공 테스트
+# 유효한 리프레시 토큰으로 액세스 토큰 갱신
+POST http://localhost:8080/v1/api/auth/refresh
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwidHlwZSI6InJlZnJlc2giLCJpYXQiOjE3MzU2NzMyMDAsImV4cCI6MTczNjI3ODAwMH0.valid_refresh_token
+
+### 토큰 갱신 실패 테스트 - 잘못된 토큰
+# 잘못된 리프레시 토큰으로 갱신 시도
+POST http://localhost:8080/v1/api/auth/refresh
+Content-Type: application/json
+Authorization: Bearer invalid_refresh_token
+
+### 토큰 갱신 실패 테스트 - Authorization 헤더 누락
+# Authorization 헤더 없이 토큰 갱신 시도
+POST http://localhost:8080/v1/api/auth/refresh
+Content-Type: application/json
+
 ###

--- a/http/auth/AuthTest.http
+++ b/http/auth/AuthTest.http
@@ -1,0 +1,36 @@
+### 사용자 등록 성공 테스트
+# 모든 필드를 포함한 사용자 등록 요청
+POST http://localhost:8080/v1/api/auth/register
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "securePassword123",
+  "name": "홍길동",
+  "profilePictureUrl": "https://example.com/profile.jpg"
+}
+
+### 중복 이메일 검증 오류 테스트
+# 이미 등록된 이메일로 가입 시도 시 오류 발생
+POST http://localhost:8080/v1/api/auth/register
+Content-Type: application/json
+
+{
+  "email": "duplicate@example.com",
+  "password": "securePassword123",
+  "name": "김철수",
+  "profilePictureUrl": "https://example.com/profile.jpg"
+}
+
+### 비밀번호 유효성 검사 테스트
+# 짧은 비밀번호로 가입 시도 시 오류 발생
+POST http://localhost:8080/v1/api/auth/register
+Content-Type: application/json
+
+{
+  "email": "user3@example.com",
+  "password": "short",
+  "name": "박지민"
+}
+
+###

--- a/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthController.kt
+++ b/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthController.kt
@@ -8,12 +8,77 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.time.ZonedDateTime
 import java.util.UUID
+
+/**
+ * 사용자 로그인 요청 데이터 클래스
+ * @property email 사용자 이메일 (필수)
+ * @property password 사용자 비밀번호 (필수)
+ */
+data class UserLoginRequest(
+    val email: String,
+    val password: String
+)
+
+/**
+ * 토큰 갱신 요청 데이터 클래스
+ * @property refreshToken 갱신 토큰 (필수)
+ */
+data class TokenRefreshRequest(
+    val refreshToken: String
+)
+
+/**
+ * 사용자 정보 데이터 클래스
+ * @property id 사용자 고유 ID
+ * @property email 사용자 이메일
+ * @property name 사용자 이름
+ * @property profilePictureUrl 프로필 사진 URL
+ */
+data class UserInfo(
+    val id: String,
+    val email: String,
+    val name: String,
+    val profilePictureUrl: String?
+)
+
+/**
+ * 로그인 응답 데이터 클래스
+ * @property accessToken 액세스 토큰
+ * @property refreshToken 갱신 토큰
+ * @property user 사용자 정보
+ * @property expiresIn 토큰 만료 시간 (초)
+ */
+data class LoginResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val user: UserInfo,
+    val expiresIn: Int = 3600
+)
+
+/**
+ * 토큰 갱신 응답 데이터 클래스
+ * @property accessToken 새로운 액세스 토큰
+ * @property refreshToken 새로운 갱신 토큰
+ * @property expiresIn 토큰 만료 시간 (초)
+ */
+data class TokenRefreshResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Int = 3600
+)
+
+/**
+ * 인증 오류 응답 데이터 클래스
+ * @property error 오류 코드
+ * @property message 오류 메시지
+ */
+data class AuthErrorResponse(
+    val error: String,
+    val message: String
+)
 
 /**
  * 사용자 등록 요청 데이터 클래스
@@ -61,7 +126,7 @@ data class ValidationErrorResponse(
 
 /**
  * 인증 관련 API 컨트롤러
- * 사용자 등록, 로그인 등의 인증 기능을 제공합니다.
+ * 사용자 등록, 로그인, 토큰 갱신 등의 인증 기능을 제공합니다.
  */
 @RestController
 @RequestMapping(path = ["v1/api/auth"])
@@ -118,5 +183,117 @@ class AuthController {
         )
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "사용자 로그인", description = "사용자 로그인을 처리합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "로그인이 성공적으로 완료되었습니다",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = LoginResponse::class)
+        )]
+    )
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 오류",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AuthErrorResponse::class)
+        )]
+    )
+    @PostMapping("/login")
+    fun loginUser(@RequestBody request: UserLoginRequest): ResponseEntity<Any> {
+        // 잘못된 이메일 또는 비밀번호 검사
+        if (request.email == "invalid@example.com" || request.password == "wrongpassword") {
+            val errorResponse = AuthErrorResponse(
+                error = ExceptionCode.AUTHENTICATION_ERROR.code,
+                message = "Invalid email or password"
+            )
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse)
+        }
+
+        // Mock 사용자 정보 생성
+        val userId = "usr_" + UUID.randomUUID().toString().replace("-", "")
+        val accessToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIkdXNlcklkIiwiaWF0IjoxNzM1NjczMjAwLCJleHAiOjE3MzU2NzY4MDB9.${
+                UUID.randomUUID().toString().replace("-", "")
+            }"
+        val refreshToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIkdXNlcklkIiwidHlwZSI6InJlZnJlc2giLCJpYXQiOjE3MzU2NzMyMDAsImV4cCI6MTczNjI3ODAwMH0.${
+                UUID.randomUUID().toString().replace("-", "")
+            }"
+
+        val userInfo = UserInfo(
+            id = userId,
+            email = request.email,
+            name = "User Name",
+            profilePictureUrl = "https://example.com/profile.jpg"
+        )
+
+        val response = LoginResponse(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            user = userInfo
+        )
+
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "토큰이 성공적으로 갱신되었습니다",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = TokenRefreshResponse::class)
+        )]
+    )
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 오류",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AuthErrorResponse::class)
+        )]
+    )
+    @PostMapping("/refresh")
+    fun refreshToken(@RequestHeader("Authorization") authHeader: String?): ResponseEntity<Any> {
+        // Authorization 헤더 검증
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            val errorResponse = AuthErrorResponse(
+                error = ExceptionCode.AUTHENTICATION_ERROR.code,
+                message = "Invalid refresh token"
+            )
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse)
+        }
+
+        val refreshToken = authHeader.substring(7) // "Bearer " 제거
+
+        // 잘못된 리프레시 토큰 검사
+        if (refreshToken == "invalid_refresh_token") {
+            val errorResponse = AuthErrorResponse(
+                error = ExceptionCode.AUTHENTICATION_ERROR.code,
+                message = "Invalid refresh token"
+            )
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse)
+        }
+
+        // 새로운 토큰 생성
+        val newAccessToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiaWF0IjoxNzM1NjczMjAwLCJleHAiOjE3MzU2NzY4MDB9.${
+                UUID.randomUUID().toString().replace("-", "")
+            }"
+        val newRefreshToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwidHlwZSI6InJlZnJlc2giLCJpYXQiOjE3MzU2NzMyMDAsImV4cCI6MTczNjI3ODAwMH0.${
+                UUID.randomUUID().toString().replace("-", "")
+            }"
+
+        val response = TokenRefreshResponse(
+            accessToken = newAccessToken,
+            refreshToken = newRefreshToken
+        )
+
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthController.kt
+++ b/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthController.kt
@@ -1,0 +1,85 @@
+package com.hangtudy.app.interfaces.api.v1.auth
+
+import com.hangtudy.app.interfaces.api.v1.exception.ExceptionCode
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.ZonedDateTime
+import java.util.UUID
+
+data class UserRegistrationRequest(
+    val email: String,
+    val password: String,
+    val name: String,
+    val profilePictureUrl: String? = null
+)
+
+data class UserRegistrationResponse(
+    val id: String,
+    val email: String,
+    val name: String,
+    val profilePictureUrl: String?,
+    val createdAt: String,
+    val workspaces: List<Any> = emptyList()
+)
+
+data class ValidationErrorResponse(
+    val error: String,
+    val message: String,
+    val details: Map<String, List<String>>
+)
+
+@RestController
+@RequestMapping(path = ["v1/api/auth"])
+@Tag(name = "Auth", description = "사용자 관리 API")
+class AuthController {
+
+    @Operation(summary = "사용자 등록", description = "사용자를 등록합니다.")
+    @ApiResponse(
+        responseCode = "201",
+        description = "사용자가 성공적으로 등록되었습니다",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = UserRegistrationResponse::class)
+        )]
+    )
+    @ApiResponse(
+        responseCode = "400",
+        description = "유효성 검사 오류",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ValidationErrorResponse::class)
+        )]
+    )
+    @PostMapping("/register")
+    fun registerUser(@RequestBody request: UserRegistrationRequest): ResponseEntity<Any> {
+
+        if (request.email == "duplicate@example.com") {
+            val errorResponse = ValidationErrorResponse(
+                error = ExceptionCode.VALIDATION_ERROR.code,
+                message = "Email already in use",
+                details = mapOf("email" to listOf("This email is already registered"))
+            )
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
+        }
+
+        val userId = "usr_" + UUID.randomUUID().toString().replace("-", "")
+        val response = UserRegistrationResponse(
+            id = userId,
+            email = request.email,
+            name = request.name,
+            profilePictureUrl = request.profilePictureUrl,
+            createdAt = ZonedDateTime.now().toString()
+        )
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthController.kt
+++ b/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthController.kt
@@ -15,6 +15,13 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.ZonedDateTime
 import java.util.UUID
 
+/**
+ * 사용자 등록 요청 데이터 클래스
+ * @property email 사용자 이메일 (필수)
+ * @property password 사용자 비밀번호 (필수)
+ * @property name 사용자 이름 (필수)
+ * @property profilePictureUrl 프로필 사진 URL (선택)
+ */
 data class UserRegistrationRequest(
     val email: String,
     val password: String,
@@ -22,6 +29,15 @@ data class UserRegistrationRequest(
     val profilePictureUrl: String? = null
 )
 
+/**
+ * 사용자 등록 응답 데이터 클래스
+ * @property id 사용자 고유 ID
+ * @property email 사용자 이메일
+ * @property name 사용자 이름
+ * @property profilePictureUrl 프로필 사진 URL
+ * @property createdAt 계정 생성 시간
+ * @property workspaces 사용자가 속한 워크스페이스 목록
+ */
 data class UserRegistrationResponse(
     val id: String,
     val email: String,
@@ -31,12 +47,22 @@ data class UserRegistrationResponse(
     val workspaces: List<Any> = emptyList()
 )
 
+/**
+ * 유효성 검사 오류 응답 데이터 클래스
+ * @property error 오류 코드
+ * @property message 오류 메시지
+ * @property details 상세 오류 정보
+ */
 data class ValidationErrorResponse(
     val error: String,
     val message: String,
     val details: Map<String, List<String>>
 )
 
+/**
+ * 인증 관련 API 컨트롤러
+ * 사용자 등록, 로그인 등의 인증 기능을 제공합니다.
+ */
 @RestController
 @RequestMapping(path = ["v1/api/auth"])
 @Tag(name = "Auth", description = "사용자 관리 API")
@@ -61,16 +87,27 @@ class AuthController {
     )
     @PostMapping("/register")
     fun registerUser(@RequestBody request: UserRegistrationRequest): ResponseEntity<Any> {
-
+        // 이메일 중복 검사
         if (request.email == "duplicate@example.com") {
             val errorResponse = ValidationErrorResponse(
                 error = ExceptionCode.VALIDATION_ERROR.code,
-                message = "Email already in use",
-                details = mapOf("email" to listOf("This email is already registered"))
+                message = "이미 사용 중인 이메일입니다",
+                details = mapOf("email" to listOf("이 이메일은 이미 등록되어 있습니다"))
             )
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
         }
 
+        // 비밀번호 유효성 검사
+        if (request.password.length < 8) {
+            val errorResponse = ValidationErrorResponse(
+                error = ExceptionCode.VALIDATION_ERROR.code,
+                message = "비밀번호가 너무 짧습니다",
+                details = mapOf("password" to listOf("비밀번호는 최소 8자 이상이어야 합니다"))
+            )
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
+        }
+
+        // 사용자 ID 생성 및 응답 구성
         val userId = "usr_" + UUID.randomUUID().toString().replace("-", "")
         val response = UserRegistrationResponse(
             id = userId,

--- a/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/exception/ExceptionCode.kt
+++ b/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/exception/ExceptionCode.kt
@@ -7,5 +7,6 @@ enum class ExceptionCode(
     val message: String,
     val httpStatus: HttpStatus
 ) {
-    VALIDATION_ERROR("VALIDATION_ERROR", "Validation error occurred", HttpStatus.BAD_REQUEST)
+    VALIDATION_ERROR("VALIDATION_ERROR", "Validation error occurred", HttpStatus.BAD_REQUEST),
+    AUTHENTICATION_ERROR("AUTHENTICATION_ERROR", "Authentication error occurred", HttpStatus.UNAUTHORIZED)
 }

--- a/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/exception/ExceptionCode.kt
+++ b/src/main/kotlin/com/hangtudy/app/interfaces/api/v1/exception/ExceptionCode.kt
@@ -7,4 +7,5 @@ enum class ExceptionCode(
     val message: String,
     val httpStatus: HttpStatus
 ) {
+    VALIDATION_ERROR("VALIDATION_ERROR", "Validation error occurred", HttpStatus.BAD_REQUEST)
 }

--- a/src/test/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthControllerTest.kt
@@ -9,6 +9,10 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
+/**
+ * AuthController 테스트 클래스
+ * 사용자 등록 API의 다양한 시나리오를 테스트합니다.
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 class AuthControllerTest {
@@ -16,17 +20,23 @@ class AuthControllerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
+    /**
+     * 사용자 등록 성공 테스트
+     * 모든 필수 필드와 선택적 필드를 포함한 요청이 성공적으로 처리되는지 확인합니다.
+     */
     @Test
     fun `사용자 등록이 성공적으로 완료되어야 한다`() {
+        // 테스트 요청 데이터 준비
         val requestBody = """
             {
                 "email": "user@example.com",
                 "password": "securePassword123",
-                "name": "User Name",
+                "name": "홍길동",
                 "profilePictureUrl": "https://example.com/profile.jpg"
             }
         """.trimIndent()
 
+        // API 요청 실행 및 응답 검증
         mockMvc.perform(
             post("/v1/api/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -35,23 +45,29 @@ class AuthControllerTest {
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.id").exists())
             .andExpect(jsonPath("$.email").value("user@example.com"))
-            .andExpect(jsonPath("$.name").value("User Name"))
+            .andExpect(jsonPath("$.name").value("홍길동"))
             .andExpect(jsonPath("$.profilePictureUrl").value("https://example.com/profile.jpg"))
             .andExpect(jsonPath("$.createdAt").exists())
             .andExpect(jsonPath("$.workspaces").isArray)
     }
 
+    /**
+     * 이메일 중복 오류 테스트
+     * 이미 등록된 이메일로 가입 시도 시 적절한 오류 응답이 반환되는지 확인합니다.
+     */
     @Test
     fun `이미 사용 중인 이메일로 가입 시도 시 유효성 검사 오류가 반환되어야 한다`() {
+        // 테스트 요청 데이터 준비
         val requestBody = """
             {
                 "email": "duplicate@example.com",
                 "password": "securePassword123",
-                "name": "User Name",
+                "name": "김철수",
                 "profilePictureUrl": "https://example.com/profile.jpg"
             }
         """.trimIndent()
 
+        // API 요청 실행 및 응답 검증
         mockMvc.perform(
             post("/v1/api/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -59,7 +75,34 @@ class AuthControllerTest {
         )
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
-            .andExpect(jsonPath("$.message").value("Email already in use"))
-            .andExpect(jsonPath("$.details.email[0]").value("This email is already registered"))
+            .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다"))
+            .andExpect(jsonPath("$.details.email[0]").value("이 이메일은 이미 등록되어 있습니다"))
+    }
+
+    /**
+     * 비밀번호 유효성 검사 테스트
+     * 짧은 비밀번호로 가입 시도 시 적절한 오류 응답이 반환되는지 확인합니다.
+     */
+    @Test
+    fun `짧은 비밀번호로 가입 시도 시 유효성 검사 오류가 반환되어야 한다`() {
+        // 테스트 요청 데이터 준비
+        val requestBody = """
+            {
+                "email": "user3@example.com",
+                "password": "short",
+                "name": "박지민"
+            }
+        """.trimIndent()
+
+        // API 요청 실행 및 응답 검증
+        mockMvc.perform(
+            post("/v1/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.message").value("비밀번호가 너무 짧습니다"))
+            .andExpect(jsonPath("$.details.password[0]").value("비밀번호는 최소 8자 이상이어야 합니다"))
     }
 }

--- a/src/test/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthControllerTest.kt
@@ -1,108 +1,268 @@
 package com.hangtudy.app.interfaces.api.v1.auth
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hangtudy.app.interfaces.api.v1.exception.ExceptionCode
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
-/**
- * AuthController 테스트 클래스
- * 사용자 등록 API의 다양한 시나리오를 테스트합니다.
- */
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(AuthController::class)
 class AuthControllerTest {
 
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    /**
-     * 사용자 등록 성공 테스트
-     * 모든 필수 필드와 선택적 필드를 포함한 요청이 성공적으로 처리되는지 확인합니다.
-     */
-    @Test
-    fun `사용자 등록이 성공적으로 완료되어야 한다`() {
-        // 테스트 요청 데이터 준비
-        val requestBody = """
-            {
-                "email": "user@example.com",
-                "password": "securePassword123",
-                "name": "홍길동",
-                "profilePictureUrl": "https://example.com/profile.jpg"
-            }
-        """.trimIndent()
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
 
-        // API 요청 실행 및 응답 검증
-        mockMvc.perform(
-            post("/v1/api/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.id").exists())
-            .andExpect(jsonPath("$.email").value("user@example.com"))
-            .andExpect(jsonPath("$.name").value("홍길동"))
-            .andExpect(jsonPath("$.profilePictureUrl").value("https://example.com/profile.jpg"))
-            .andExpect(jsonPath("$.createdAt").exists())
-            .andExpect(jsonPath("$.workspaces").isArray)
+    @Nested
+    @DisplayName("사용자 등록 API 테스트")
+    inner class RegisterUserTest {
+
+        @Test
+        @DisplayName("유효한 사용자 정보로 등록 성공")
+        fun `should register user successfully with valid data`() {
+            // given
+            val request = UserRegistrationRequest(
+                email = "test@example.com",
+                password = "securePassword123",
+                name = "테스트 사용자",
+                profilePictureUrl = "https://example.com/profile.jpg"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.name").value("테스트 사용자"))
+                .andExpect(jsonPath("$.profilePictureUrl").value("https://example.com/profile.jpg"))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.workspaces").isArray)
+        }
+
+        @Test
+        @DisplayName("프로필 사진 URL 없이 등록 성공")
+        fun `should register user successfully without profile picture`() {
+            // given
+            val request = UserRegistrationRequest(
+                email = "test2@example.com",
+                password = "securePassword123",
+                name = "테스트 사용자2"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.email").value("test2@example.com"))
+                .andExpect(jsonPath("$.name").value("테스트 사용자2"))
+                .andExpect(jsonPath("$.profilePictureUrl").isEmpty)
+        }
+
+        @Test
+        @DisplayName("중복된 이메일로 등록 실패")
+        fun `should fail to register with duplicate email`() {
+            // given
+            val request = UserRegistrationRequest(
+                email = "duplicate@example.com",
+                password = "securePassword123",
+                name = "중복 사용자"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.VALIDATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다"))
+                .andExpect(jsonPath("$.details.email").exists())
+        }
+
+        @Test
+        @DisplayName("짧은 비밀번호로 등록 실패")
+        fun `should fail to register with short password`() {
+            // given
+            val request = UserRegistrationRequest(
+                email = "test@example.com",
+                password = "short",
+                name = "테스트 사용자"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.VALIDATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("비밀번호가 너무 짧습니다"))
+                .andExpect(jsonPath("$.details.password").exists())
+        }
     }
 
-    /**
-     * 이메일 중복 오류 테스트
-     * 이미 등록된 이메일로 가입 시도 시 적절한 오류 응답이 반환되는지 확인합니다.
-     */
-    @Test
-    fun `이미 사용 중인 이메일로 가입 시도 시 유효성 검사 오류가 반환되어야 한다`() {
-        // 테스트 요청 데이터 준비
-        val requestBody = """
-            {
-                "email": "duplicate@example.com",
-                "password": "securePassword123",
-                "name": "김철수",
-                "profilePictureUrl": "https://example.com/profile.jpg"
-            }
-        """.trimIndent()
+    @Nested
+    @DisplayName("사용자 로그인 API 테스트")
+    inner class LoginUserTest {
 
-        // API 요청 실행 및 응답 검증
-        mockMvc.perform(
-            post("/v1/api/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-        )
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
-            .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다"))
-            .andExpect(jsonPath("$.details.email[0]").value("이 이메일은 이미 등록되어 있습니다"))
+        @Test
+        @DisplayName("유효한 로그인 정보로 로그인 성공")
+        fun `should login successfully with valid credentials`() {
+            // given
+            val request = UserLoginRequest(
+                email = "user@example.com",
+                password = "securePassword123"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.user.id").exists())
+                .andExpect(jsonPath("$.user.email").value("user@example.com"))
+                .andExpect(jsonPath("$.user.name").value("User Name"))
+                .andExpect(jsonPath("$.user.profilePictureUrl").value("https://example.com/profile.jpg"))
+                .andExpect(jsonPath("$.expiresIn").value(3600))
+        }
+
+        @Test
+        @DisplayName("잘못된 이메일로 로그인 실패")
+        fun `should fail to login with invalid email`() {
+            // given
+            val request = UserLoginRequest(
+                email = "invalid@example.com",
+                password = "securePassword123"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.AUTHENTICATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("Invalid email or password"))
+        }
+
+        @Test
+        @DisplayName("잘못된 비밀번호로 로그인 실패")
+        fun `should fail to login with wrong password`() {
+            // given
+            val request = UserLoginRequest(
+                email = "user@example.com",
+                password = "wrongpassword"
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.AUTHENTICATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("Invalid email or password"))
+        }
     }
 
-    /**
-     * 비밀번호 유효성 검사 테스트
-     * 짧은 비밀번호로 가입 시도 시 적절한 오류 응답이 반환되는지 확인합니다.
-     */
-    @Test
-    fun `짧은 비밀번호로 가입 시도 시 유효성 검사 오류가 반환되어야 한다`() {
-        // 테스트 요청 데이터 준비
-        val requestBody = """
-            {
-                "email": "user3@example.com",
-                "password": "short",
-                "name": "박지민"
-            }
-        """.trimIndent()
+    @Nested
+    @DisplayName("토큰 갱신 API 테스트")
+    inner class RefreshTokenTest {
 
-        // API 요청 실행 및 응답 검증
-        mockMvc.perform(
-            post("/v1/api/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-        )
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
-            .andExpect(jsonPath("$.message").value("비밀번호가 너무 짧습니다"))
-            .andExpect(jsonPath("$.details.password[0]").value("비밀번호는 최소 8자 이상이어야 합니다"))
+        @Test
+        @DisplayName("유효한 리프레시 토큰으로 갱신 성공")
+        fun `should refresh token successfully with valid refresh token`() {
+            // given
+            val validRefreshToken =
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwidHlwZSI6InJlZnJlc2giLCJpYXQiOjE3MzU2NzMyMDAsImV4cCI6MTczNjI3ODAwMH0.valid_refresh_token"
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer $validRefreshToken")
+            )
+                .andExpect(status().isOk)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.expiresIn").value(3600))
+        }
+
+        @Test
+        @DisplayName("잘못된 리프레시 토큰으로 갱신 실패")
+        fun `should fail to refresh token with invalid refresh token`() {
+            // given
+            val invalidRefreshToken = "invalid_refresh_token"
+
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer $invalidRefreshToken")
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.AUTHENTICATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("Invalid refresh token"))
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더 없이 토큰 갱신 실패")
+        fun `should fail to refresh token without authorization header`() {
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.AUTHENTICATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("Invalid refresh token"))
+        }
+
+        @Test
+        @DisplayName("잘못된 형식의 Authorization 헤더로 토큰 갱신 실패")
+        fun `should fail to refresh token with malformed authorization header`() {
+            // when & then
+            mockMvc.perform(
+                post("/v1/api/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "InvalidFormat token")
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value(ExceptionCode.AUTHENTICATION_ERROR.code))
+                .andExpect(jsonPath("$.message").value("Invalid refresh token"))
+        }
     }
 }

--- a/src/test/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/hangtudy/app/interfaces/api/v1/auth/AuthControllerTest.kt
@@ -1,0 +1,65 @@
+package com.hangtudy.app.interfaces.api.v1.auth
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `사용자 등록이 성공적으로 완료되어야 한다`() {
+        val requestBody = """
+            {
+                "email": "user@example.com",
+                "password": "securePassword123",
+                "name": "User Name",
+                "profilePictureUrl": "https://example.com/profile.jpg"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/v1/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.email").value("user@example.com"))
+            .andExpect(jsonPath("$.name").value("User Name"))
+            .andExpect(jsonPath("$.profilePictureUrl").value("https://example.com/profile.jpg"))
+            .andExpect(jsonPath("$.createdAt").exists())
+            .andExpect(jsonPath("$.workspaces").isArray)
+    }
+
+    @Test
+    fun `이미 사용 중인 이메일로 가입 시도 시 유효성 검사 오류가 반환되어야 한다`() {
+        val requestBody = """
+            {
+                "email": "duplicate@example.com",
+                "password": "securePassword123",
+                "name": "User Name",
+                "profilePictureUrl": "https://example.com/profile.jpg"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/v1/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.message").value("Email already in use"))
+            .andExpect(jsonPath("$.details.email[0]").value("This email is already registered"))
+    }
+}


### PR DESCRIPTION
## 📋 Summary
사용자 인증 플로우를 위한 MockAPI를 구현하고 포괄적인 테스트를 추가했습니다.

## 🚀 Changes
### ✨ 새로운 기능
- **사용자 등록 API** (`POST /v1/api/auth/register`)
  
- **사용자 로그인 API** (`POST /v1/api/auth/login`)
  
- **토큰 갱신 API** (`POST /v1/api/auth/refresh`)
  
  ### 🧪 테스트
- **단위 테스트**: 9개 테스트 케이스 (WebMvcTest)
- **HTTP 테스트**: 성공/실패 시나리오별 테스트 파일
- 모든 API 엔드포인트 검증 완료

## 📁 Modified Files
- `src/main/kotlin/.../auth/AuthController.kt` - 인증 API 구현
- `src/main/kotlin/.../exception/ExceptionCode.kt` - 에러 코드 추가
- `src/test/kotlin/.../auth/AuthControllerTest.kt` - 단위 테스트
- `http/auth/AuthTest.http` - HTTP 테스트

## 🔍 Test Cases
### 사용자 등록 (4개)
- ✅ 유효한 정보로 등록 성공
- ✅ 프로필 사진 없이 등록 성공
- ❌ 중복 이메일 등록 실패
- ❌ 짧은 비밀번호 등록 실패

### 사용자 로그인 (3개)
- ✅ 유효한 인증정보로 로그인 성공
- ❌ 잘못된 이메일로 로그인 실패
- ❌ 잘못된 비밀번호로 로그인 실패

### 토큰 갱신 (4개)
- ✅ 유효한 리프레시 토큰으로 갱신 성공
- ❌ 잘못된 토큰으로 갱신 실패
- ❌ Authorization 헤더 누락 시 실패
- ❌ 잘못된 헤더 형식으로 실패

## 🎛️ API Endpoints